### PR TITLE
fix: modify-attribute-annotation

### DIFF
--- a/src/MyBusinessBusinessInformation/Attribute.php
+++ b/src/MyBusinessBusinessInformation/Attribute.php
@@ -33,7 +33,7 @@ class Attribute extends \Google\Collection
    */
   public $valueType;
   /**
-   * @var array[]
+   * @var (bool|string)[]
    */
   public $values;
 
@@ -94,14 +94,14 @@ class Attribute extends \Google\Collection
     return $this->valueType;
   }
   /**
-   * @param array[]
+   * @param (bool|string)[]
    */
   public function setValues($values)
   {
     $this->values = $values;
   }
   /**
-   * @return array[]
+   * @return (bool|string)[]
    */
   public function getValues()
   {


### PR DESCRIPTION
Since the array was waiting for a bool to come in but the actual value was a bool, I will create a PR for correcting the problem. If you notice this, I would be happy to respond.

```
__construct(): Argument #5 ($value) must be of type array, bool given,
```